### PR TITLE
Render character as image for better readability

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,191 @@
+[*.cs]
+
+# CS8632: The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.
+dotnet_diagnostic.cs8632.severity = none
+# IDE0305: Disable "Use collection expression for fluent (IDE0305)" message.
+dotnet_diagnostic.IDE0305.severity = none
+
+[*.{appxmanifest,asax,ascx,aspx,axaml,axml,build,config,cs,cshtml,csproj,css,dbml,discomap,dtd,htm,html,js,json,jsproj,jsx,lsproj,master,njsproj,nuspec,paml,proj,props,proto,razor,resjson,resw,resx,scss,skin,StyleCop,targets,tasks,ts,tsx,vb,vbproj,xaml,xamlx,xml,xoml,xsd}]
+indent_style = tab
+indent_size = 4
+tab_width = 4
+
+[*]
+
+# Microsoft .NET properties
+csharp_new_line_before_members_in_object_initializers = true
+csharp_preferred_modifier_order = public, private, protected, internal, new, static, abstract, virtual, sealed, readonly, override, extern, unsafe, volatile, async:suggestion
+csharp_prefer_braces = true:none
+csharp_space_after_cast = true
+csharp_style_var_elsewhere = false:suggestion
+csharp_style_var_for_built_in_types = false:suggestion
+csharp_style_var_when_type_is_apparent = false:suggestion
+
+dotnet_naming_rule.private_constants_rule.import_to_resharper = as_predefined
+dotnet_naming_rule.private_constants_rule.severity = warning
+dotnet_naming_rule.private_constants_rule.style = private_field_style
+dotnet_naming_rule.private_constants_rule.symbols = private_constants_symbols
+
+dotnet_naming_rule.private_instance_fields_rule.import_to_resharper = as_predefined
+dotnet_naming_rule.private_instance_fields_rule.severity = warning
+dotnet_naming_rule.private_instance_fields_rule.style = private_field_style
+dotnet_naming_rule.private_instance_fields_rule.symbols = private_instance_fields_symbols
+
+dotnet_naming_rule.private_static_fields_rule.import_to_resharper = as_predefined
+dotnet_naming_rule.private_static_fields_rule.severity = warning
+dotnet_naming_rule.private_static_fields_rule.style = private_field_style
+dotnet_naming_rule.private_static_fields_rule.symbols = private_static_fields_symbols
+
+dotnet_naming_rule.private_static_readonly_rule.import_to_resharper = as_predefined
+dotnet_naming_rule.private_static_readonly_rule.severity = warning
+dotnet_naming_rule.private_static_readonly_rule.style = private_field_style
+dotnet_naming_rule.private_static_readonly_rule.symbols = private_static_readonly_symbols
+
+## Naming styles
+dotnet_naming_style.private_field_style.capitalization = camel_case
+dotnet_naming_style.private_field_style.required_prefix = _
+
+dotnet_naming_style.pascal_case_style.capitalization = pascal_case
+dotnet_naming_style.camel_case_style.capitalization = camel_case
+
+## Symbols
+dotnet_naming_symbols.private_constants_symbols.applicable_accessibilities = private
+dotnet_naming_symbols.private_constants_symbols.applicable_kinds = field
+dotnet_naming_symbols.private_constants_symbols.required_modifiers = const
+
+dotnet_naming_symbols.private_instance_fields_symbols.applicable_accessibilities = private
+dotnet_naming_symbols.private_instance_fields_symbols.applicable_kinds = field
+
+dotnet_naming_symbols.private_static_fields_symbols.applicable_accessibilities = private
+dotnet_naming_symbols.private_static_fields_symbols.applicable_kinds = field
+dotnet_naming_symbols.private_static_fields_symbols.required_modifiers = static
+
+dotnet_naming_symbols.private_static_readonly_symbols.applicable_accessibilities = private
+dotnet_naming_symbols.private_static_readonly_symbols.applicable_kinds = field
+dotnet_naming_symbols.private_static_readonly_symbols.required_modifiers = static,readonly
+
+dotnet_separate_import_directive_groups = true
+dotnet_style_parentheses_in_arithmetic_binary_operators = never_if_unnecessary:none
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:none
+dotnet_style_parentheses_in_relational_binary_operators = never_if_unnecessary:none
+dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
+dotnet_style_predefined_type_for_member_access = true:suggestion
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:suggestion
+
+
+
+# ReSharper properties
+resharper_apply_auto_detected_rules = false
+resharper_braces_for_for = required
+resharper_braces_for_foreach = required
+resharper_braces_for_ifelse = required
+resharper_braces_for_while = required
+resharper_braces_redundant = true
+resharper_csharp_keep_blank_lines_in_declarations = 1
+resharper_csharp_naming_rule.private_constants = AaBb:do_not_check
+resharper_csharp_naming_rule.private_static_fields = AaBb:do_not_check
+resharper_csharp_naming_rule.private_static_readonly = AaBb:do_not_check
+resharper_for_other_types = use_explicit_type
+resharper_show_autodetect_configure_formatting_tip = false
+resharper_space_within_single_line_array_initializer_braces = false
+resharper_use_indent_from_vs = false
+
+# ReSharper inspection severities
+resharper_arrange_redundant_parentheses_highlighting = hint
+resharper_arrange_this_qualifier_highlighting = none
+resharper_arrange_type_member_modifiers_highlighting = hint
+resharper_arrange_type_modifiers_highlighting = hint
+resharper_built_in_type_reference_style_for_member_access_highlighting = hint
+resharper_built_in_type_reference_style_highlighting = hint
+resharper_coerced_equals_using_highlighting = none
+resharper_comment_typo_highlighting = none
+resharper_convert_if_statement_to_return_statement_highlighting = none
+resharper_convert_to_using_declaration_highlighting = none
+resharper_enforce_do_while_statement_braces_highlighting = suggestion
+resharper_enforce_fixed_statement_braces_highlighting = suggestion
+resharper_enforce_foreach_statement_braces_highlighting = suggestion
+resharper_enforce_for_statement_braces_highlighting = suggestion
+resharper_enforce_if_statement_braces_highlighting = suggestion
+resharper_enforce_lock_statement_braces_highlighting = suggestion
+resharper_enforce_using_statement_braces_highlighting = suggestion
+resharper_enforce_while_statement_braces_highlighting = suggestion
+resharper_identifier_typo_highlighting = none
+resharper_inconsistent_naming_highlighting = none
+resharper_inline_out_variable_declaration_highlighting = none
+resharper_markup_attribute_typo_highlighting = none
+resharper_markup_text_typo_highlighting = none
+resharper_string_literal_typo_highlighting = none
+resharper_suggest_var_or_type_deconstruction_declarations_highlighting = none
+resharper_suggest_var_or_type_elsewhere_highlighting = suggestion
+resharper_suggest_var_or_type_simple_types_highlighting = suggestion
+dotnet_style_operator_placement_when_wrapping = beginning_of_line
+end_of_line = crlf
+csharp_indent_labels = flush_left
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_null_propagation = true:suggestion
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
+dotnet_style_prefer_auto_properties = true:silent
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_collection_initializer = true:suggestion
+dotnet_style_prefer_simplified_boolean_expressions = true:suggestion
+dotnet_style_prefer_conditional_expression_over_assignment = true:silent
+dotnet_style_prefer_conditional_expression_over_return = true:silent
+dotnet_style_explicit_tuple_names = true:suggestion
+dotnet_style_prefer_inferred_tuple_names = true:suggestion
+dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
+dotnet_style_prefer_compound_assignment = true:suggestion
+dotnet_style_prefer_simplified_interpolation = true:suggestion
+dotnet_style_namespace_match_folder = true:suggestion
+csharp_using_directive_placement = outside_namespace:error
+csharp_prefer_simple_using_statement = false:warning
+csharp_style_namespace_declarations = block_scoped:silent
+csharp_style_prefer_method_group_conversion = true:silent
+csharp_style_expression_bodied_methods = false:silent
+csharp_style_expression_bodied_constructors = false:silent
+csharp_style_expression_bodied_operators = false:silent
+csharp_style_expression_bodied_properties = true:silent
+csharp_style_expression_bodied_indexers = true:silent
+csharp_style_expression_bodied_accessors = true:silent
+csharp_style_expression_bodied_lambdas = true:silent
+csharp_style_expression_bodied_local_functions = false:silent
+csharp_style_throw_expression = true:suggestion
+csharp_style_prefer_null_check_over_type_check = true:suggestion
+csharp_prefer_simple_default_expression = true:suggestion
+csharp_style_prefer_local_over_anonymous_function = true:suggestion
+csharp_style_prefer_index_operator = true:suggestion
+insert_final_newline = true
+csharp_space_around_binary_operators = before_and_after
+csharp_style_prefer_range_operator = true:suggestion
+csharp_style_implicit_object_creation_when_type_is_apparent = true:suggestion
+csharp_style_prefer_tuple_swap = true:suggestion
+csharp_style_inlined_variable_declaration = true:warning
+csharp_style_deconstructed_variable_declaration = true:warning
+csharp_style_unused_value_assignment_preference = discard_variable:suggestion
+csharp_style_unused_value_expression_statement_preference = discard_variable:silent
+dotnet_style_readonly_field = true:warning
+csharp_prefer_static_local_function = true:suggestion
+dotnet_style_allow_multiple_blank_lines_experimental = true:silent
+dotnet_style_allow_statement_immediately_after_block_experimental = true:silent
+csharp_style_allow_embedded_statements_on_same_line_experimental = true:silent
+csharp_style_allow_blank_lines_between_consecutive_braces_experimental = true:silent
+csharp_style_allow_blank_line_after_colon_in_constructor_initializer_experimental = true:silent
+csharp_style_conditional_delegate_call = true:warning
+csharp_style_prefer_parameter_null_checking = true:suggestion
+dotnet_code_quality_unused_parameters = all:suggestion
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary:warning
+csharp_style_prefer_switch_expression = true:suggestion
+csharp_style_prefer_pattern_matching = true:silent
+dotnet_style_qualification_for_field = false:warning
+dotnet_style_qualification_for_property = false:warning
+csharp_style_pattern_matching_over_is_with_cast_check = true:warning
+csharp_style_pattern_matching_over_as_with_null_check = true:warning
+csharp_style_prefer_not_pattern = true:suggestion
+csharp_style_prefer_extended_property_pattern = true:suggestion
+dotnet_style_qualification_for_method = false:warning
+dotnet_style_qualification_for_event = false:warning
+
+
+[*.{csproj,props}]
+
+indent_style = space
+indent_size = 2

--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,4 @@ $RECYCLE.BIN/
 _NCrunch*
 
 appsettings.development.json
+.azuredevops

--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,4 @@ _NCrunch*
 
 appsettings.development.json
 .azuredevops
+.vs

--- a/GlobalSettingsStorage.DotSettings
+++ b/GlobalSettingsStorage.DotSettings
@@ -1,0 +1,44 @@
+<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/CodeEditing/Intellisense/CodeCompletion/IntelliSenseCompletingCharacters/CSharpCompletingCharacters/UpgradedFromVSSettings/@EntryValue">True</s:Boolean>
+	<s:String x:Key="/Default/CodeInspection/JsInspections/LanguageLevel/@EntryValue">ECMAScript 2015</s:String>
+	
+	<s:String x:Key="/Default/CodeStyle/CodeCleanup/Profiles/=Custom_0020Code_0020Cleanup/@EntryIndexedValue">&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;Profile name="Custom Code Cleanup"&gt;&lt;AspOptimizeRegisterDirectives&gt;True&lt;/AspOptimizeRegisterDirectives&gt;&lt;CSReorderTypeMembers&gt;True&lt;/CSReorderTypeMembers&gt;&lt;CSCodeStyleAttributes ArrangeTypeAccessModifier="True" ArrangeTypeMemberAccessModifier="True" SortModifiers="True" ArrangeArgumentsStyle="True" RemoveRedundantParentheses="True" AddMissingParentheses="True" ArrangeAttributes="True" ArrangeCodeBodyStyle="True" ArrangeTrailingCommas="True" ArrangeObjectCreation="True" ArrangeDefaultValue="True" /&gt;&lt;XAMLCollapseEmptyTags&gt;False&lt;/XAMLCollapseEmptyTags&gt;&lt;RemoveCodeRedundancies&gt;True&lt;/RemoveCodeRedundancies&gt;&lt;CSUseAutoProperty&gt;True&lt;/CSUseAutoProperty&gt;&lt;CSMakeFieldReadonly&gt;True&lt;/CSMakeFieldReadonly&gt;&lt;CSMakeAutoPropertyGetOnly&gt;True&lt;/CSMakeAutoPropertyGetOnly&gt;&lt;CSArrangeQualifiers&gt;True&lt;/CSArrangeQualifiers&gt;&lt;CSFixBuiltinTypeReferences&gt;True&lt;/CSFixBuiltinTypeReferences&gt;&lt;CSOptimizeUsings&gt;&lt;OptimizeUsings&gt;True&lt;/OptimizeUsings&gt;&lt;/CSOptimizeUsings&gt;&lt;CSShortenReferences&gt;True&lt;/CSShortenReferences&gt;&lt;CSReformatCode&gt;True&lt;/CSReformatCode&gt;&lt;CSharpFormatDocComments&gt;True&lt;/CSharpFormatDocComments&gt;&lt;/Profile&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeCleanup/RecentlyUsedProfile/@EntryValue">Custom Code Cleanup</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_ACCESSOR_ATTRIBUTE_ON_SAME_LINE_EX/@EntryValue">NEVER</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_ACCESSORHOLDER_ATTRIBUTE_ON_SAME_LINE_EX/@EntryValue">NEVER</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_FIELD_ATTRIBUTE_ON_SAME_LINE_EX/@EntryValue">NEVER</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/JavaScriptCodeFormatting/QUOTE_STYLE/@EntryValue">SingleQuoted</s:String>
+	<s:String x:Key="/Default/CodeStyle/CSharpVarKeywordUsage/ForBuiltInTypes/@EntryValue">UseExplicitType</s:String>
+	<s:String x:Key="/Default/CodeStyle/CSharpVarKeywordUsage/ForOtherTypes/@EntryValue">UseExplicitType</s:String>
+	<s:String x:Key="/Default/CodeStyle/CSharpVarKeywordUsage/ForSimpleTypes/@EntryValue">UseExplicitType</s:String>
+	<s:Boolean x:Key="/Default/CodeStyle/Generate/=Overrides/@KeyIndexDefined">True</s:Boolean>
+	<s:String x:Key="/Default/CodeStyle/Generate/=Overrides/Options/=Async/@EntryIndexedValue">False</s:String>
+	<s:Boolean x:Key="/Default/CodeStyle/Naming/CSharpAutoNaming/IsNotificationDisabled/@EntryValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/DotPeek/DotPeekLicenseAgreement/Accepted/@EntryValue">True</s:Boolean>
+	<s:Int64 x:Key="/Default/DotPeek/DotPeekLicenseAgreement/AcceptedVersion/@EntryValue">1100</s:Int64>
+	<s:Boolean x:Key="/Default/Environment/ExternalSources/Decompiler/DecompileMethodBodies/@EntryValue">False</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/ExternalSources/FirstTimeFormShown/@EntryValue">True</s:Boolean>
+	<s:String x:Key="/Default/Environment/ExternalSources/NavigationMode/@EntryValue">Disabled</s:String>
+	<s:Int64 x:Key="/Default/Environment/Hierarchy/GeneratedFilesCacheKey/Timestamp/@EntryValue">899</s:Int64>
+	<s:Boolean x:Key="/Default/Environment/IntraTextAdornmentsOptions/ShowVSParameterNameHintsDisableNotification/@EntryValue">False</s:Boolean>
+	<s:Int64 x:Key="/Default/Environment/SearchAndNavigation/DefaultOccurrencesGroupingIndices/=JetBrains_002EReSharper_002EFeatures_002EInspections_002EAnalyzeReferences_002ERemoveUnused_002EUnusedReferencesDescriptor/@EntryIndexedValue">0</s:Int64>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpKeepExistingMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpPlaceEmbeddedOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpUseContinuousIndentInsideBracesMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
+	<s:String x:Key="/Default/Environment/UpdatesManger/LastUpdateCheck/@EntryValue">03/28/2022 13:26:17</s:String>
+	<s:String x:Key="/Default/Environment/UserInterface/ShortcutSchemeName/@EntryValue">VS</s:String>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/SPACE_AFTER_TYPECAST_PARENTHESES/@EntryValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/SPACE_WITHIN_SINGLE_LINE_ARRAY_INITIALIZER_BRACES/@EntryValue">False</s:Boolean>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/ValueAnalysisMode/@EntryValue">OPTIMISTIC</s:String>
+	<s:Boolean x:Key="/Default/Housekeeping/FeatureSuggestion/FeatureSuggestionManager/DisabledSuggesters/=EditorConfigFeatureSuggester/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Housekeeping/FeatureSuggestion/FeatureSuggestionManager/DisabledSuggesters/=TabNavigationExplainer/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Housekeeping/GlobalSettingsUpgraded/IsUpgraded/@EntryValue">True</s:Boolean>
+	<s:String x:Key="/Default/Housekeeping/FeedbackReport/SelectedUserIdentificator/@EntryValue">anonymous</s:String>
+	<s:Boolean x:Key="/Default/Housekeeping/IntellisenseHousekeeping/HintUsed/@EntryValue">True</s:Boolean>
+	<s:String x:Key="/Default/Housekeeping/Layout/DialogWindows/RefactoringWizardWindow/Location/@EntryValue">-604,-385</s:String>
+	<s:String x:Key="/Default/Housekeeping/OptionsDialog/SelectedPageId/@EntryValue">CodeCleanupOptionsPage</s:String>
+	<s:Boolean x:Key="/Default/Housekeeping/UpgradeFromExceptionReport/UpgradePerformed/@EntryValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Housekeeping/VsActionManager/IsShortcutBrowserEnabled/@EntryValue">True</s:Boolean>
+	<s:String x:Key="/Default/Housekeeping/WhatsNewShown/WhatsNewShownIndexedEntry/=RS0/@EntryIndexedValue">2021.3</s:String>
+	<s:Boolean x:Key="/Default/ReSpeller/ReSpellerEnabled/@EntryValue">False</s:Boolean></wpf:ResourceDictionary>

--- a/NihongoBot/HiraganaJob.cs
+++ b/NihongoBot/HiraganaJob.cs
@@ -2,51 +2,54 @@ using Telegram.Bot;
 using Quartz;
 using Microsoft.Data.Sqlite;
 using Dapper;
+using Telegram.Bot.Types;
 
 public class HiraganaJob : IJob
 {
-    public async Task Execute(IJobExecutionContext context)
-    {
-        using SqliteConnection connection = new("Data Source=nihongoBot.db");
+	public async Task Execute(IJobExecutionContext context)
+	{
+		using SqliteConnection connection = new("Data Source=nihongoBot.db");
 
-        connection.Execute("INSERT INTO TriggerLog (TriggerTime) VALUES (@time);", new { time = DateTime.UtcNow });
+		connection.Execute("INSERT INTO TriggerLog (TriggerTime) VALUES (@time);", new { time = DateTime.UtcNow });
 
-        Console.WriteLine("Sending Hiragana character...");
+		Console.WriteLine("Sending Hiragana character...");
 
-        if (Program.HiraganaList.Count == 0) return;
-        Random random = new();
-        HiraganaEntry hiragana = Program.HiraganaList[random.Next(Program.HiraganaList.Count)];
+		if (Program.HiraganaList.Count == 0) return;
+		Random random = new();
+		HiraganaEntry hiragana = Program.HiraganaList[random.Next(Program.HiraganaList.Count)];
 
-        IEnumerable<int> chatIds = [.. connection.Query<int>("SELECT TelegramId FROM Users")];
+		IEnumerable<int> chatIds = [.. connection.Query<int>("SELECT TelegramId FROM Users")];
 
-        foreach (int id in chatIds)
-        {
-            byte[] imageBytes = Program.RenderCharacterToImage(hiragana.Character);
-            using MemoryStream stream = new(imageBytes);
-            await Program.BotClient.SendPhotoAsync(id, new Telegram.Bot.Types.InputFiles.InputOnlineFile(stream, "hiragana.png"), $"What is the Romaji for: {hiragana.Character}?");
+		foreach (int id in chatIds)
+		{
+			byte[] imageBytes = Program.RenderCharacterToImage(hiragana.Character);
+			using MemoryStream stream = new(imageBytes);
+			await Program.BotClient.SendPhotoAsync(id,
+				 InputFile.FromStream(stream, "hiragana.png"),
+				caption: $"What is the Romaji for this Hiragana character?");
 
-            // check if the user has answered previous question in the HiraganaAnswers table and if not, update the streak to 0
-            connection.Execute("UPDATE Users SET Streak = 0 WHERE TelegramId = @id AND NOT EXISTS (SELECT * FROM HiraganaAnswers WHERE TelegramId = @id AND Correct = 1);", new { id });
-            
-            // Insert the Hiragana character into the HiraganaAnswers table
-            connection.Execute("INSERT INTO HiraganaAnswers (TelegramId, Character) VALUES (@id, @character);", new { id, character = hiragana.Character });
-        }
-        await RescheduleNextTriggersAsync(context.Scheduler);
-        connection.Close();
-    }
-    
-    private static async Task RescheduleNextTriggersAsync(IScheduler scheduler)
-    {
-        var triggers = TriggerGenerator.GetNextTriggers(10, 21); // Generate new triggers
+			// check if the user has answered previous question in the HiraganaAnswers table and if not, update the streak to 0
+			connection.Execute("UPDATE Users SET Streak = 0 WHERE TelegramId = @id AND NOT EXISTS (SELECT * FROM HiraganaAnswers WHERE TelegramId = @id AND Correct = 1);", new { id });
 
-        IJobDetail job = JobBuilder.Create<HiraganaJob>()
-            .Build();
+			// Insert the Hiragana character into the HiraganaAnswers table
+			connection.Execute("INSERT INTO HiraganaAnswers (TelegramId, Character) VALUES (@id, @character);", new { id, character = hiragana.Character });
+		}
+		await RescheduleNextTriggersAsync(context.Scheduler);
+		connection.Close();
+	}
 
-        await scheduler.ScheduleJobs(new Dictionary<IJobDetail, IReadOnlyCollection<ITrigger>>
-        {
-            { job, triggers }
-        }, true);
+	private static async Task RescheduleNextTriggersAsync(IScheduler scheduler)
+	{
+		var triggers = TriggerGenerator.GetNextTriggers(10, 21); // Generate new triggers
 
-        Console.WriteLine("New random triggers scheduled.");
-    }
+		IJobDetail job = JobBuilder.Create<HiraganaJob>()
+			.Build();
+
+		await scheduler.ScheduleJobs(new Dictionary<IJobDetail, IReadOnlyCollection<ITrigger>>
+		{
+			{ job, triggers }
+		}, true);
+
+		Console.WriteLine("New random triggers scheduled.");
+	}
 }

--- a/NihongoBot/HiraganaJob.cs
+++ b/NihongoBot/HiraganaJob.cs
@@ -21,7 +21,9 @@ public class HiraganaJob : IJob
 
         foreach (int id in chatIds)
         {
-            await Program.BotClient.SendMessage(id, $"What is the Romaji for: {hiragana.Character}?");
+            byte[] imageBytes = Program.RenderCharacterToImage(hiragana.Character);
+            using MemoryStream stream = new(imageBytes);
+            await Program.BotClient.SendPhotoAsync(id, new Telegram.Bot.Types.InputFiles.InputOnlineFile(stream, "hiragana.png"), $"What is the Romaji for: {hiragana.Character}?");
 
             // check if the user has answered previous question in the HiraganaAnswers table and if not, update the streak to 0
             connection.Execute("UPDATE Users SET Streak = 0 WHERE TelegramId = @id AND NOT EXISTS (SELECT * FROM HiraganaAnswers WHERE TelegramId = @id AND Correct = 1);", new { id });

--- a/NihongoBot/HiraganaJob.cs
+++ b/NihongoBot/HiraganaJob.cs
@@ -33,7 +33,7 @@ public class HiraganaJob : IJob
 			connection.Execute("UPDATE Users SET Streak = 0 WHERE TelegramId = @id AND NOT EXISTS (SELECT * FROM HiraganaAnswers WHERE TelegramId = @id AND Correct = 1);", new { id });
 
 			// Insert the Hiragana character into the HiraganaAnswers table
-			connection.Execute("INSERT INTO HiraganaAnswers (TelegramId, Character) VALUES (@id, character = hiragana.Character });
+			connection.Execute("INSERT INTO HiraganaAnswers (TelegramId, Character) VALUES (@id, @character);", new { id, character = hiragana.Character });
 		}
 		await RescheduleNextTriggersAsync(context.Scheduler);
 		connection.Close();

--- a/NihongoBot/HiraganaJob.cs
+++ b/NihongoBot/HiraganaJob.cs
@@ -3,6 +3,7 @@ using Quartz;
 using Microsoft.Data.Sqlite;
 using Dapper;
 using Telegram.Bot.Types;
+using SkiaSharp;
 
 public class HiraganaJob : IJob
 {
@@ -32,7 +33,7 @@ public class HiraganaJob : IJob
 			connection.Execute("UPDATE Users SET Streak = 0 WHERE TelegramId = @id AND NOT EXISTS (SELECT * FROM HiraganaAnswers WHERE TelegramId = @id AND Correct = 1);", new { id });
 
 			// Insert the Hiragana character into the HiraganaAnswers table
-			connection.Execute("INSERT INTO HiraganaAnswers (TelegramId, Character) VALUES (@id, @character);", new { id, character = hiragana.Character });
+			connection.Execute("INSERT INTO HiraganaAnswers (TelegramId, Character) VALUES (@id, character = hiragana.Character });
 		}
 		await RescheduleNextTriggersAsync(context.Scheduler);
 		connection.Close();

--- a/NihongoBot/NihongoBot.csproj
+++ b/NihongoBot/NihongoBot.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="Dapper" Version="2.1.66" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.2" />
     <PackageReference Include="Quartz" Version="3.14.0" />
+    <PackageReference Include="System.Drawing.Common" Version="9.0.3" />
     <PackageReference Include="Telegram.Bot" Version="22.4.4" />
   </ItemGroup>
 <ItemGroup>

--- a/NihongoBot/NihongoBot.csproj
+++ b/NihongoBot/NihongoBot.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="Dapper" Version="2.1.66" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.2" />
     <PackageReference Include="Quartz" Version="3.14.0" />
+    <PackageReference Include="SkiaSharp" Version="3.116.1" />
     <PackageReference Include="System.Drawing.Common" Version="9.0.3" />
     <PackageReference Include="Telegram.Bot" Version="22.4.4" />
   </ItemGroup>
@@ -19,6 +20,9 @@
     <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
   </None>
   <None Update="appsettings.Development.json">
+    <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+  </None>
+  <None Update="fonts\NotoSansJP-Regular.ttf">
     <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
   </None>
   <None Update="hiragana.json">

--- a/NihongoBot/Program.cs
+++ b/NihongoBot/Program.cs
@@ -8,6 +8,8 @@ using Microsoft.Data.Sqlite;
 using Dapper;
 using Microsoft.Extensions.Configuration;
 using Telegram.Bot.Types.ReplyMarkups;
+using System.Drawing;
+using System.Drawing.Imaging;
 
 class Program
 {
@@ -181,4 +183,21 @@ class Program
         new BotCommand { Command = "register", Description = "Register to receive Hiragana practice messages" },
         new BotCommand { Command = "streak", Description = "Check your current streak" },
     ];
+
+    private static byte[] RenderCharacterToImage(string character)
+    {
+        int width = 100;
+        int height = 100;
+        using Bitmap bitmap = new(width, height);
+        using Graphics graphics = Graphics.FromImage(bitmap);
+        using Font font = new("Arial", 48);
+        using SolidBrush brush = new(Color.Black);
+
+        graphics.FillRectangle(Brushes.White, 0, 0, width, height);
+        graphics.DrawString(character, font, brush, new PointF(10, 10));
+
+        using MemoryStream memoryStream = new();
+        bitmap.Save(memoryStream, ImageFormat.Png);
+        return memoryStream.ToArray();
+    }
 }

--- a/NihongoBot/Program.cs
+++ b/NihongoBot/Program.cs
@@ -198,19 +198,32 @@ class Program
 		using SKPaint paint = new()
 		{
 			Color = SKColors.Black,
-			IsAntialias = true,
-			TextSize = fontSize
+			IsAntialias = true
+		};
+
+		string fontPath = "fonts/NotoSansJP-Regular.ttf";
+		//check if file exists
+		if (!File.Exists(fontPath))
+		{
+			Console.WriteLine("Font file not found.");
+			return Array.Empty<byte>();
+		}
+		using SKTypeface typeface = SKTypeface.FromFile(fontPath);
+		using SKFont font = new()
+		{
+			Size = fontSize,
+			Typeface = typeface
 		};
 
 		canvas.Clear(SKColors.White);
 
 		// Measure the string to center it
 		SKRect textBounds = new();
-		paint.MeasureText(character, ref textBounds);
-		float x = (width - textBounds.Width) / 2;
+		font.MeasureText(character, out textBounds);
+		float x = (width - textBounds.Width) / 2 - 10;
 		float y = (height + textBounds.Height) / 2;
 
-		canvas.DrawText(character, x, y, paint);
+		canvas.DrawText(character, x, y, SKTextAlign.Left, font, paint);
 
 		using SKImage image = SKImage.FromBitmap(bitmap);
 		using SKData data = image.Encode(SKEncodedImageFormat.Png, 100);


### PR DESCRIPTION
Fixes #11

Render the character as an image to improve readability.

* Add `RenderCharacterToImage` method in `NihongoBot/Program.cs` to convert the character to an image.
* Update `NihongoBot/HiraganaJob.cs` to call `RenderCharacterToImage` and send the image instead of the text character.
* Add `System.Drawing.Common` package to `NihongoBot/NihongoBot.csproj` for image rendering.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/dennisblokland/NihongoBot/pull/26?shareId=4b8afbb6-a8bf-4884-b4d2-f2da0ee48d19).