### PR TITLE
Ensure TimeGenerator segments cover full range

### DIFF
--- a/NihongoBot.Application/Helpers/TimeGenerator.cs
+++ b/NihongoBot.Application/Helpers/TimeGenerator.cs
@@ -22,21 +22,19 @@ namespace NihongoBot.Application.Helpers
 				return possibleTimes; // Return all possible times if count exceeds available slots
 			}
 
-			// Divide the range into `count` segments
-			int segmentSize = possibleTimes.Count / count;
+                        // Divide the range into `count` segments using floating-point division
+                        for (int i = 0; i < count; i++)
+                        {
+                                // Compute segment boundaries so that the final segment reaches the last index
+                                int minIndex = (int)Math.Floor((double)i * possibleTimes.Count / count);
+                                int maxIndex = (int)Math.Floor((double)(i + 1) * possibleTimes.Count / count) - 1;
 
-			for (int i = 0; i < count; i++)
-			{
-				// Pick a random time within each segment
-				int minIndex = i * segmentSize;
-				int maxIndex = Math.Min((i + 1) * segmentSize, possibleTimes.Count) - 1;
-
-				if (minIndex <= maxIndex)
-				{
-					int randomIndex = rand.Next(minIndex, maxIndex + 1);
-					result.Add(possibleTimes[randomIndex]);
-				}
-			}
+                                if (minIndex <= maxIndex)
+                                {
+                                        int randomIndex = rand.Next(minIndex, maxIndex + 1);
+                                        result.Add(possibleTimes[randomIndex]);
+                                }
+                        }
 
 			result.Sort(); // Sort times in ascending order
 			return result;

--- a/Tests/NihongoBot.Application.Tests/Helpers/TimeGeneratorTests.cs
+++ b/Tests/NihongoBot.Application.Tests/Helpers/TimeGeneratorTests.cs
@@ -1,0 +1,27 @@
+using NihongoBot.Application.Helpers;
+
+namespace NihongoBot.Application.Tests.Helpers;
+
+public class TimeGeneratorTests
+{
+        [Fact]
+        public void GetRandomTimes_ShouldBeAbleToSelectFinalInterval()
+        {
+                TimeOnly start = new(0, 0);
+                TimeOnly end = new(1, 0);
+                const int count = 3;
+
+                bool found = false;
+
+                for (int i = 0; i < 1000 && !found; i++)
+                {
+                        List<TimeOnly> times = TimeGenerator.GetRandomTimes(start, end, count);
+                        if (times.Contains(end))
+                        {
+                                found = true;
+                        }
+                }
+
+                Assert.True(found, "Final interval was never returned.");
+        }
+}


### PR DESCRIPTION
## Summary
- fix TimeGenerator to compute segment boundaries with floating-point math so last interval is selectable
- add unit test verifying final interval can be returned

## Testing
- `dotnet test` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_6895f1a2e14c8329a4e91c6a0b719f8d