### PR TITLE
Update HangfireSchedulerService.cs

### DIFF
--- a/NihongoBot.Application/Services/HangfireSchedulerService.cs
+++ b/NihongoBot.Application/Services/HangfireSchedulerService.cs
@@ -215,7 +215,8 @@ public class HangfireSchedulerService
 			}
 			_questionRepository.Update(question);
 		}
-
+		
+		await _questionRepository.SaveChangesAsync(cancellationToken);
 		IEnumerable<Question> unansweredQuestions = await _questionRepository.GetExpiredPendingAcceptanceQuestionsAsync(cancellationToken);
 
 		foreach (Question question in unansweredQuestions)


### PR DESCRIPTION
This pull request introduces a minor but important change to the `HangfireSchedulerService`. The update ensures that changes to questions are persisted to the database before retrieving expired pending acceptance questions, improving data consistency.

* Added a call to `_questionRepository.SaveChangesAsync` after updating questions to ensure all changes are saved before further processing.